### PR TITLE
[INFRA] Update link checker action URL in GHA workflow file

### DIFF
--- a/.github/workflows/check-md-links.yaml
+++ b/.github/workflows/check-md-links.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@master
-        -   uses: gaurav-nelson/github-action-markdown-link-check@v1
+        -   uses: tcort/github-action-markdown-link-check@v1
             with:
                 use-quiet-mode: no
                 use-verbose-mode: no


### PR DESCRIPTION
Update link checker action URL in GHA workflow file: `gaurav-nelson/github-action-markdown-link-check` is no longer maintained, and has been superseded by
`tcort/github-action-markdown-link-check`. Documentation: https://github.com/tcort/github-action-markdown-link-check